### PR TITLE
Updated manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -15,8 +15,8 @@ from app import app, init_db
 from json import load
 from urllib2 import urlopen
 from flask import g
-from flask.ext.hookserver import Hooks
-from flask.ext.script import Manager
+from flask_hookserver import Hooks
+from flask_script import Manager
 
 logging.basicConfig(filename=app.config.get('LOG_FILENAME'),
                     level=app.config.get('LOG_LEVEL', logging.WARNING),


### PR DESCRIPTION
Running manage.py from Ubuntu 14.04 with python 2.7, give to warnings

/usr/local/lib/python2.7/dist-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.hookserver is deprecated, use flask_hookserver instead.

/usr/local/lib/python2.7/dist-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.script is deprecated, use flask_script instead.

Updated with "nondeprecated" version