### PR TITLE
Add a folder path to download directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Download files from **Put.IO** to configured downloads directory:
   Defaults to 256kb.
 * -p PARENT_ID, --parent_id PARENT_ID
   Parent folder to download files from.
+* -f FOLDER, --folder FOLDER
+  Folder in the downloads directory download to.
 
 ### Transfers
 

--- a/putio_automator/commands/files.py
+++ b/putio_automator/commands/files.py
@@ -27,7 +27,6 @@ def download(limit=None, chunk_size=256, parent_id=0, folder=""):
     "Download files"
     files = app.client.File.list(parent_id)
     app.logger.info('%s files found' % len(files))
-    folder = "/" + folder
 
     if len(files):
         def func(connection):
@@ -46,8 +45,9 @@ def download(limit=None, chunk_size=256, parent_id=0, folder=""):
                     current_file.download(dest=app.config['INCOMPLETE'], delete_after_download=True, chunk_size=int(chunk_size)*1024)
                     app.logger.info('downloaded file: %s' % current_file)
 
-                    path = os.path.join(app.config['INCOMPLETE'], current_file.name)
-                    shutil.move(path, app.config['DOWNLOADS'] + folder)
+                    src = os.path.join(app.config['INCOMPLETE'], current_file.name)
+                    dest = os.path.join(app.config['DOWNLOADS'], folder)
+                    shutil.move(src, dest)
 
                     conn.execute('insert into downloads (id, name, size) values (?, ?, ?)', (current_file.id, current_file.name, current_file.size))
                     connection.commit()

--- a/putio_automator/commands/files.py
+++ b/putio_automator/commands/files.py
@@ -23,10 +23,11 @@ class List(Command):
 manager.add_command('list', List())
 
 @manager.command
-def download(limit=None, chunk_size=256, parent_id=0):
+def download(limit=None, chunk_size=256, parent_id=0, folder=""):
     "Download files"
     files = app.client.File.list(parent_id)
     app.logger.info('%s files found' % len(files))
+    folder = "/" + folder
 
     if len(files):
         def func(connection):
@@ -46,7 +47,7 @@ def download(limit=None, chunk_size=256, parent_id=0):
                     app.logger.info('downloaded file: %s' % current_file)
 
                     path = os.path.join(app.config['INCOMPLETE'], current_file.name)
-                    shutil.move(path, app.config['DOWNLOADS'])
+                    shutil.move(path, app.config['DOWNLOADS'] + folder)
 
                     conn.execute('insert into downloads (id, name, size) values (?, ?, ?)', (current_file.id, current_file.name, current_file.size))
                     connection.commit()


### PR DESCRIPTION
This PR adds an option to the download command for a destination folder. It allows for placing the file into a specified folder in the downloads directory. 