### PR TITLE
python / pip version issue 

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-python:slim
+FROM resin/%%RESIN_MACHINE_NAME%%-debian:jessie
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
https://forums.resin.io/t/pip-version-mismatch/2715/19

Fixes the following build error:
```
[main] Traceback (most recent call last):
[main] File "/usr/local/bin/pip", line 7, in <module>
[main] from pip import main
[main] File "/usr/lib/python2.7/dist-packages/pip/__init__.py", line 72, in <module>
[main] from pip.log import logger
[main] File "/usr/lib/python2.7/dist-packages/pip/log.py", line 6, in <module>
[main] import logging
[main] File "/usr/local/lib/python2.7/logging/__init__.py", line 26, in <module>
[main] import sys, os, time, cStringIO, traceback, warnings, weakref, collections
[main] File "/usr/local/lib/python2.7/weakref.py", line 14, in <module>
[main] from _weakref import (
[main] ImportError: cannot import name _remove_dead_weakref
```

However, the following errors occur now:
```
[main]  Downloading/unpacking pip from https://pypi.python.org/packages/ac/95/a05b56bb975efa78d3557efa36acaf9cf5d2fd0ee0062060493687432e03/pip-9.0.3-py2.py3-none-any.whl#md5=d512ceb964f38ba31addb8142bc657cb
[main]  Downloading/unpacking setuptools from https://pypi.python.org/packages/20/d7/04a0b689d3035143e2ff288f4b9ee4bf6ed80585cc121c90bfd85a1a8c2e/setuptools-39.0.1-py2.py3-none-any.whl#md5=ca299c7acd13a72e1171a3697f2b99bc
[main]  Installing collected packages: pip, setuptools
[main]    Found existing installation: pip 1.5.6
[main]      Not uninstalling pip at /usr/lib/python2.7/dist-packages, owned by OS
[main]    Found existing installation: setuptools 5.5.1
[main]      Not uninstalling setuptools at /usr/lib/python2.7/dist-packages, owned by OS
[main]  Successfully installed pip setuptools
[main]  Cleaning up...
[main]  Downloading/unpacking putio-automator
[main]    Downloading putio_automator-1.0.2-py2-none-any.whl
[main]  Downloading/unpacking pyinotify==0.9.6 (from putio-automator)
[main]    Running setup.py (path:/tmp/pip-build-jnfBpn/pyinotify/setup.py) egg_info for package pyinotify
[main]  Downloading/unpacking Flask==0.12 (from putio-automator)
[main]  Downloading/unpacking putio.py==6.0.0 (from putio-automator)
[main]    Downloading putio.py-6.0.0.tar.gz
[main]    Running setup.py (path:/tmp/pip-build-jnfBpn/putio.py/setup.py) egg_info for package putio.py
[main]  Downloading/unpacking tus.py==1.2.0 (from putio-automator)
[main]    Downloading tus.py-1.2.0.tar.gz
[main]    Running setup.py (path:/tmp/pip-build-jnfBpn/tus.py/setup.py) egg_info for package tus.py
[main]  Downloading/unpacking click==6.7 (from putio-automator)
[main]  Downloading/unpacking python-dotenv==0.6.3 (from putio-automator)
[main]    Downloading python_dotenv-0.6.3-py2.py3-none-any.whl
[main]  Downloading/unpacking cogapp==2.5.1 (from putio-automator)
[main]    Downloading cogapp-2.5.1.tar.gz
[main]    Running setup.py (path:/tmp/pip-build-jnfBpn/cogapp/setup.py) egg_info for package cogapp
[main]  Downloading/unpacking requests==2.13.0 (from putio-automator)
[main]  Downloading/unpacking supervisor==3.3.1 (from putio-automator)
[main]    Running setup.py (path:/tmp/pip-build-jnfBpn/supervisor/setup.py) egg_info for package supervisor
[main]      warning: no previously-included files matching '*' found under directory 'docs/.build'
[main]  Downloading/unpacking itsdangerous==0.24 (from putio-automator)
[main]    Running setup.py (path:/tmp/pip-build-jnfBpn/itsdangerous/setup.py) egg_info for package itsdangerous
[main]      warning: no previously-included files matching '*' found under directory 'docs/_build'
[main]  Downloading/unpacking six==1.10.0 (from putio-automator)
[main]    Downloading six-1.10.0-py2.py3-none-any.whl
[main]  Downloading/unpacking packaging==16.8 (from putio-automator)
[main]    Downloading packaging-16.8-py2.py3-none-any.whl
[main]  Downloading/unpacking pyparsing==2.1.10 (from putio-automator)
[main]  Downloading/unpacking Flask-Script==2.0.5 (from putio-automator)
[main]    Running setup.py (path:/tmp/pip-build-jnfBpn/Flask-Script/setup.py) egg_info for package Flask-Script
[main]      warning: no previously-included files matching '*.pyc' found under directory 'docs'
[main]      warning: no previously-included files matching '*.pyo' found under directory 'docs'
[main]      no previously-included directories found matching 'docs/_build'
[main]      no previously-included directories found matching 'docs/_themes/.git'
[main]  Downloading/unpacking appdirs==1.4.2 (from putio-automator)
[main]    Downloading appdirs-1.4.2-py2.py3-none-any.whl
[main]  Downloading/unpacking Jinja2==2.9.5 (from putio-automator)
[main]  Downloading/unpacking MarkupSafe==0.23 (from putio-automator)
[main]    Downloading MarkupSafe-0.23.tar.gz
[main]    Running setup.py (path:/tmp/pip-build-jnfBpn/MarkupSafe/setup.py) egg_info for package MarkupSafe
[main]  Downloading/unpacking Werkzeug==0.11.15 (from putio-automator)
[main]  Downloading/unpacking meld3==1.0.2 (from putio-automator)
[main]    Downloading meld3-1.0.2-py2.py3-none-any.whl
[main]  Installing collected packages: putio-automator, pyinotify, Flask, putio.py, tus.py, click, python-dotenv, cogapp, requests, supervisor, itsdangerous, six, packaging, pyparsing, Flask-Script, appdirs, Jinja2, MarkupSafe, Werkzeug, meld3
[main]    Running setup.py install for pyinotify
[main]    Could not find .egg-info directory in install record for pyinotify==0.9.6 (from putio-automator)
[main]    Running setup.py install for putio.py
[main]    Could not find .egg-info directory in install record for putio.py==6.0.0 (from putio-automator)
[main]    Running setup.py install for tus.py
[main]      Installing tus-upload script to /usr/local/bin
[main]      Installing tus-resume script to /usr/local/bin
[main]    Could not find .egg-info directory in install record for tus.py==1.2.0 (from putio-automator)
[main]    Running setup.py install for cogapp
[main]      changing mode of build/scripts-2.7/cog.py from 644 to 755
[main]      changing mode of /usr/local/bin/cog.py to 755
[main]    Could not find .egg-info directory in install record for cogapp==2.5.1 (from putio-automator)
[main]    Found existing installation: requests 2.4.3
[main]      Not uninstalling requests at /usr/lib/python2.7/dist-packages, owned by OS
[main]    Running setup.py install for supervisor
[main]      warning: no previously-included files matching '*' found under directory 'docs/.build'
[main]      Skipping installation of /usr/local/lib/python2.7/dist-packages/supervisor/__init__.py (namespace package)
[main]      Installing /usr/local/lib/python2.7/dist-packages/supervisor-3.3.1-py2.7-nspkg.pth
[main]      Installing echo_supervisord_conf script to /usr/local/bin
[main]      Installing pidproxy script to /usr/local/bin
[main]      Installing supervisorctl script to /usr/local/bin
[main]      Installing supervisord script to /usr/local/bin
[main]    Could not find .egg-info directory in install record for supervisor==3.3.1 (from putio-automator)
[main]    Running setup.py install for itsdangerous
[main]      warning: no previously-included files matching '*' found under directory 'docs/_build'
[main]    Could not find .egg-info directory in install record for itsdangerous==0.24 (from putio-automator)
[main]    Found existing installation: six 1.8.0
[main]      Not uninstalling six at /usr/lib/python2.7/dist-packages, owned by OS
[main]    Running setup.py install for Flask-Script
[main]      warning: no previously-included files matching '*.pyc' found under directory 'docs'
[main]      warning: no previously-included files matching '*.pyo' found under directory 'docs'
[main]      no previously-included directories found matching 'docs/_build'
[main]      no previously-included directories found matching 'docs/_themes/.git'
[main]    Could not find .egg-info directory in install record for Flask-Script==2.0.5 (from putio-automator)
[main]  Compiling /tmp/pip-build-jnfBpn/Jinja2/jinja2/asyncfilters.py ...
[main]    File "/tmp/pip-build-jnfBpn/Jinja2/jinja2/asyncfilters.py", line 7
[main]      async def auto_to_seq(value):
[main]              ^
[main]  SyntaxError: invalid syntax
[main]  Compiling /tmp/pip-build-jnfBpn/Jinja2/jinja2/asyncsupport.py ...
[main]    File "/tmp/pip-build-jnfBpn/Jinja2/jinja2/asyncsupport.py", line 22
[main]      async def concat_async(async_gen):
[main]              ^
[main]  SyntaxError: invalid syntax
[main]    Running setup.py install for MarkupSafe
[main]      building 'markupsafe._speedups' extension
[main]      arm-linux-gnueabihf-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format-security -fPIC -I/usr/include/python2.7 -c markupsafe/_speedups.c -o build/temp.linux-armv8l-2.7/markupsafe/_speedups.o
[main]      unable to execute 'arm-linux-gnueabihf-gcc': No such file or directory
[main]      ==========================================================================
[main]      WARNING: The C extension could not be compiled, speedups are not enabled.
[main]      Failure information, if any, is above.
[main]      Retrying the build without the C extension now.
[main]      ==========================================================================
[main]      WARNING: The C extension could not be compiled, speedups are not enabled.
[main]      Plain-Python installation succeeded.
[main]      ==========================================================================
[main]    Could not find .egg-info directory in install record for MarkupSafe==0.23 (from putio-automator)
[main]  Successfully installed putio-automator pyinotify Flask putio.py tus.py click python-dotenv cogapp requests supervisor itsdangerous six packaging pyparsing Flask-Script appdirs Jinja2 MarkupSafe Werkzeug meld3
```

App works as expected afterwards